### PR TITLE
Fix the user_test.rb so it passes

### DIFF
--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -2,12 +2,10 @@ require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
   test "user course enrollment" do
-    user = FactoryGirl.build(:user)
-    course = FactoryGirl.build(:course)
-    enrollment = FactoryGirl.build(:enrollment)
+    user = FactoryGirl.create(:user)
+    course = FactoryGirl.create(:course)
+    enrollment = FactoryGirl.create(:enrollment, :user => user, :course => course)
 
-    expected =  true
-    actual = user.enrolled_in?(course)
-    assert_equal expected, actual
+    assert user.enrolled_in?(course)
   end
 end


### PR DESCRIPTION
Your test was basically perfect, John.  Here's the one gotcha, that doesn't have to do with testing so much as it has to do with how rails works.

Our user code looks like this:

```
class User < ActiveRecord::Base
  has_many :courses
  has_many :enrollments
  has_many :enrolled_courses, through: :enrollments, source: :course

  # Include default devise modules. Others available are:
  # :confirmable, :lockable, :timeoutable and :omniauthable
  devise :database_authenticatable, :registerable,
         :recoverable, :rememberable, :trackable, :validatable

  def enrolled_in?(course)
    return enrolled_courses.include?(course)
  end

end
```

The `enrolled_courses` is going to pull the courses the user is enrolled in **from the database**, so calling `build`, does everything fine, but since it doesn't save it to the database, `enrolled_courses` is a blank list, which is causing the test to fail.

By changing this to `create` you serialize the data into the database.

The other gotcha we have is the enrollment we're creating in our database isn't an arbitrary enrollment (which would create a new placeholder user and a new placeholder course), we need to connect it to the items we previously factoried up.

You basically had the test, just a couple small gotchas!

Hope this helped!
